### PR TITLE
Performance.md review

### DIFF
--- a/Performance.md
+++ b/Performance.md
@@ -27,7 +27,7 @@ For a program `Pgm` in a programming language `PL`, we use the [K framework](htt
 
 A logical proof checker can automatically verify `proof_check(PI(Pgm, PL))`. We then generate a ZK proof demonstrating the correctness of an execution trace of `proof_check`.
 
-In essence, we generate a ZK proof that validates the correctness of a logical proof, which in turn verifires the correctness of `Pgm` written in language `PL`. This is why we refer to this benchmark set as Proofs of Proofs--it generates (ZK) proofs of (logical) proofs.
+In essence, we generate a ZK proof that validates the correctness of a logical proof, which in turn verifies the correctness of `Pgm` written in the language `PL`. This is why we refer to this benchmark set as Proofs of Proofs--it generates (ZK) proofs of (logical) proofs.
 
 ## ZK Backend Evaluation
 This describes the ZK backends we evaluated, including details on their performance.
@@ -43,18 +43,18 @@ The ZK backends under consideration are:
 ## Performance Tables
 
 - Machine Spec: AMD Ryzen 9 7950X(16 cores/32 threads/128GB), 4090RTX
-- Memory Swap: 108GB
+- Memory Swap: 108 GB
 - Performance Time Measured in Seconds
-- The execution time for all implementations, except RISC Zero, was measured by taking the difference between the start and end timestamps for each execution phace.
-- RISC Zero has its own performance counter, which was used to measure the execution time and cycles.
+- The execution time for all implementations, except RISC Zero, was measured by taking the difference between the start and end timestamps for each execution phase.
+- RISC Zero has its own performance counter, which is used to measure the execution time and cycles.
 - The "CPU" prefix denotes implementation **without** GPU acceleration
 - The "GPU" prefix denotes implementation **with** GPU acceleration
 - Last Update: Dec 19th, 2023
 
 **Other option for this section**
-Some key details about the performance data for the ZK backends. The evaluations were carried out on an AMD Ryzen 9 7950X machine, with 16 cores, 32 threads, and 128GB of memory, paired with a 4090RTX GPU and 108GB of memory swap.
+Some key details about the performance data for the ZK backends. The evaluations were carried out on an AMD Ryzen 9 7950X machine, with 16 cores, 32 threads, and 128 GB of memory, paired with a 4090RTX GPU and 108 GB of memory swap.
 
-The performance time is measured in seconds, and it's important to note how these times were calculated. For all implementations, except RISC Zero, the execution time was determined by measuring the time differnce between the start and end timestamps of each execution phase. RISC Zero, has its own performance counter that was utilized to measure both the execution time and cycles.
+The performance time is measured in seconds, and it's important to note how these times were calculated. For all implementations, except RISC Zero, the execution time was determined by measuring the time difference between the start and end timestamps of each execution phase. RISC Zero, has its own performance counter that was utilized to measure both the execution time and cycles.
 
 We've also noted where the implementation is using CPU or GPU acceleration. If you see the prefix "CPU", this refers to an implementation without GPU acceleration, whereas "GPU" denotes an implementation that utilized GPU acceleration.
 
@@ -190,14 +190,14 @@ The main implementation for the zkLLVM $PI^2$ implementation can be found [here]
 
 ### Lurk Implementation Details
 
-Lurk is an interpreted programming language. When we run a Lurk examplee, we are actually executing the interpreter, which in turn executes the program. The execution time includes the time needed for the interpreter to load every function and definition. Consequently, we cannot measure the compilation time of the program itself.
+Lurk is an interpreted programming language. When we run a Lurk example, we are actually executing the interpreter, which in turn executes the program. The execution time includes the time needed for the interpreter to load every function and definition. Consequently, we cannot measure the compilation time of the program itself.
 
 Executing large Lurk examples requires an increase in swap memory, which results in slower execution times compared to other implementations. This limitation makes it challenging to measure and compare execution times between Lurk and other implementations accurately. Despite having 128GB of RAM plus 108GB of swap memory, we were still unable to execute most of the $PI^2$ examples in Lurk. The symbol `∞` in the performance tables indicates this inability.
 
 The `--rc n` flag in Lurk is used to enhance execution performance of larger programs. The `rc` value indicates the number of iterations that Lurk bundles together in a single [Nova](https://github.com/microsoft/Nova) folding step. Here, iterations represent reduction steps in the [Lurk Universal Circuit](https://blog.lurk-lang.org/posts/circuit-spec/).
 
 In terms of parallelism, higher `rc` values allow Lurk to generate more partial witnesses simultaneously. However, a larger `rc` value also requires more memory to execute the program. The default `rc` value is 10. For the `batch-transfer` example, we used `rc=400`. In smaller cases, increasing the `rc` value can reduce execution time, which is why it's used for programs with
-over than 100K iterations.
+over 100K iterations.
 
 The Lurk examples were run on the following version:
 
@@ -237,7 +237,7 @@ Generally, a single cycle corresponds to one RISC-V operation. However, some ope
 
 zkLLVM does not support GPU acceleration in any stage, so there are no GPU results for these experiments. 
 
-The proof and verification for zkLLVM were genereted using the command `transpiler -m gen-test-proof`.
+The proof and verification for zkLLVM were generated using the command `transpiler -m gen-test-proof`.
 
 The versions of the individual tools used for the examples are as follows:
 

--- a/Performance.md
+++ b/Performance.md
@@ -71,10 +71,10 @@ This section was last updated Dec 19th, 2023.
 | [batch-transfer](https://github.com/Pi-Squared-Network/proof-checker-public/blob/master/cairo/tests/direct-implementation/cairo0/batch_transfer.cairo)  |         6.825 |         30.196 |           0.869 |         37.890 |
 | [perceptron](https://github.com/Pi-Squared-Network/proof-checker-public/blob/master/cairo/tests/direct-implementation/cairo0/perceptron.cairo)          |         0.448 |          0.166 |           0.008 |          0.662 |
 | [svm](https://github.com/Pi-Squared-Network/proof-checker-public/blob/master/cairo/tests/direct-implementation/cairo0/svm.cairo)                        |         0.443 |          0.176 |           0.008 |          0.627 |
-> The programs were compiled using Cairo Zero's default compiler and were proved and verified using Lambdaworks Cairo Platinum Prover (v0.3.0)
 
-> Last Update: Dec 22th, 2023
+*Last Update: Dec 22th, 2023*
 
+The programs were compiled using the default compiler of Cairo Zero, and were proven and verified using Lambdaworks Cairo Platinum Prover (v0.3.0)
 </details>
 
 <details open>
@@ -87,9 +87,9 @@ This section was last updated Dec 19th, 2023.
 | [perceptron](https://github.com/Pi-Squared-Network/proof-checker-public/blob/master/cairo/tests/direct-implementation/cairo1/perceptron.cairo)          |         0.592 |          0.029 |           0.003 |          0.624 |
 | [svm](https://github.com/Pi-Squared-Network/proof-checker-public/blob/master/cairo/tests/direct-implementation/cairo1/svm.cairo)                        |         0.593 |          0.032 |           0.003 |          0.628 |
 
-> The programs were compiled using LambdaClass Cairo-VM (v1.0.0-rc0) and were proved and verified using Lambdaworks Cairo Platinum Prover (v0.3.0)
+*Last Update: Jan 10th, 2024*
 
->Last Update: Jan 10th, 2024
+The programs were compiled using LambdaClass Cairo-VM (v1.0.0-rc0), and were proven and verified using Lambdaworks Cairo Platinum Prover (v0.3.0)
 </details>
 
 <details open>
@@ -102,9 +102,9 @@ This section was last updated Dec 19th, 2023.
 | [perceptron](https://github.com/Pi-Squared-Network/proof-checker-public/blob/master/lurk/tests/direct-implementation/perceptron.lurk)          |         11 |          3.501 |          0.830 |           0.541 |           0.579 |          4.042 |          1.409 |
 | [svm](https://github.com/Pi-Squared-Network/proof-checker-public/blob/master/lurk/tests/direct-implementation/svm.lurk)                        |          9 |          1.832 |          0.820 |           0.538 |           0.598 |          2.370 |          1.418 |
 
-  > <sup>*</sup>Using `lurk --rc 400 batch_transfer.lurk`, other tests doesn't use `--rc`
-  
-  > Last Update: Dec 19th, 2023
+*Last Update: Dec 19th, 2023*
+
+<sup>*</sup> The batch-transfer example utilizes `lurk --rc 400 batch_transfer.lurk`, while other tests do not use the `--rc` tag
 </details>
 
 <details open>
@@ -117,8 +117,7 @@ This section was last updated Dec 19th, 2023.
 | [perceptron](https://github.com/Pi-Squared-Network/proof-checker-public/blob/master/risc0/tests/direct-implementation/guest/src/perceptron.rs)       |  21156  |     0.017     |     0.028     |      2.355     |      0.595     |      0.001      |      0.002      |      2.373     |      0.625     |
 | [svm](https://github.com/Pi-Squared-Network/proof-checker-public/blob/master/risc0/tests/direct-implementation/guest/src/svm5.rs)                    |  21156  |     0.028     |     0.028     |      2.351     |      0.602     |      0.002      |      0.002      |      2.381     |      0.632     |
 
-
-  > Last Update: Dec 22th, 2023
+*Last Update: Dec 22th, 2023*
 </details>
 
 <details open>
@@ -131,7 +130,7 @@ This section was last updated Dec 19th, 2023.
 | [perceptron](https://github.com/Pi-Squared-Network/proof-checker-public/blob/master/zkllvm/tests/direct-implementation/perceptron)         |                0.750 |                 0.130 |
 | [svm](https://github.com/Pi-Squared-Network/proof-checker-public/blob/master/zkllvm/tests/direct-implementation/svm)                       |                0.730 |                 0.132 |
 
-  > Last Update: Jan 8th, 2024
+*Last Update: Jan 8th, 2024*
 </details>
 
 
@@ -148,9 +147,9 @@ This section was last updated Dec 19th, 2023.
 | [perceptron-goal](https://github.com/Pi-Squared-Network/proof-checker-public/blob/master/lurk/tests/proofs-of-proofs/test_perceptron_goal.lurk)         | 6404208|             ∞  |             ∞  |              ∞  |               ∞ |              ∞ |              ∞ |
 | [svm-goal](https://github.com/Pi-Squared-Network/proof-checker-public/blob/master/lurk/tests/proofs-of-proofs/test_svm_goal.lurk)                       | 6404208|             ∞  |             ∞  |              ∞  |               ∞ |              ∞ |              ∞ |
 
-> <sup>*</sup> Using `lurk --rc 400 ...`
+*Last Update: Dec 19th, 2023*
 
-  > Last Update: Dec 19th, 2023
+<sup>*</sup> The impreflex example utilizes `lurk --rc 400 batch_transfer.lurk`, while other tests do not use the `--rc` tag
 </details>
 
 <details open>

--- a/Performance.md
+++ b/Performance.md
@@ -16,8 +16,6 @@ The programs include:
 - `svm`: a [support vector machine (SVM)](https://en.wikipedia.org/wiki/Support_vector_machine)
   model.
 
-The pseudocode for these examples is provided at the end of this document.
-
 For each ZK backend, we directly implement these programs in the respective programming language and generate ZK proofs of their execution traces.
 
 ### Proofs of Proofs
@@ -42,23 +40,11 @@ The ZK backends under consideration are:
 
 ## Performance Tables
 
-- Machine Spec: AMD Ryzen 9 7950X(16 cores/32 threads/128GB), 4090RTX
-- Memory Swap: 108 GB
-- Performance Time Measured in Seconds
-- The execution time for all implementations, except RISC Zero, was measured by taking the difference between the start and end timestamps for each execution phase.
-- RISC Zero has its own performance counter, which is used to measure the execution time and cycles.
-- The "CPU" prefix denotes implementation **without** GPU acceleration
-- The "GPU" prefix denotes implementation **with** GPU acceleration
-- Last Update: Dec 19th, 2023
-
-**Other option for this section**
 Some key details about the performance data for the ZK backends. The evaluations were carried out on an AMD Ryzen 9 7950X machine, with 16 cores, 32 threads, and 128 GB of memory, paired with a 4090RTX GPU and 108 GB of memory swap.
 
 The performance time is measured in seconds, and it's important to note how these times were calculated. For all implementations, except RISC Zero, the execution time was determined by measuring the time difference between the start and end timestamps of each execution phase. RISC Zero, has its own performance counter that was utilized to measure both the execution time and cycles.
 
 We've also noted where the implementation is using CPU or GPU acceleration. If you see the prefix "CPU", this refers to an implementation without GPU acceleration, whereas "GPU" denotes an implementation that utilized GPU acceleration.
-
-This section was last updated Dec 19th, 2023.
 
 ### Direct Implementation
 
@@ -72,7 +58,6 @@ This section was last updated Dec 19th, 2023.
 | [perceptron](https://github.com/Pi-Squared-Network/proof-checker-public/blob/master/cairo/tests/direct-implementation/cairo0/perceptron.cairo)          |         0.448 |          0.166 |           0.008 |          0.662 |
 | [svm](https://github.com/Pi-Squared-Network/proof-checker-public/blob/master/cairo/tests/direct-implementation/cairo0/svm.cairo)                        |         0.443 |          0.176 |           0.008 |          0.627 |
 
-*Last Update: Dec 22th, 2023*
 
 The programs were compiled using the default compiler of Cairo Zero, and were proven and verified using Lambdaworks Cairo Platinum Prover (v0.3.0)
 </details>
@@ -87,7 +72,6 @@ The programs were compiled using the default compiler of Cairo Zero, and were pr
 | [perceptron](https://github.com/Pi-Squared-Network/proof-checker-public/blob/master/cairo/tests/direct-implementation/cairo1/perceptron.cairo)          |         0.592 |          0.029 |           0.003 |          0.624 |
 | [svm](https://github.com/Pi-Squared-Network/proof-checker-public/blob/master/cairo/tests/direct-implementation/cairo1/svm.cairo)                        |         0.593 |          0.032 |           0.003 |          0.628 |
 
-*Last Update: Jan 10th, 2024*
 
 The programs were compiled using LambdaClass Cairo-VM (v1.0.0-rc0), and were proven and verified using Lambdaworks Cairo Platinum Prover (v0.3.0)
 </details>
@@ -102,7 +86,6 @@ The programs were compiled using LambdaClass Cairo-VM (v1.0.0-rc0), and were pro
 | [perceptron](https://github.com/Pi-Squared-Network/proof-checker-public/blob/master/lurk/tests/direct-implementation/perceptron.lurk)          |         11 |          3.501 |          0.830 |           0.541 |           0.579 |          4.042 |          1.409 |
 | [svm](https://github.com/Pi-Squared-Network/proof-checker-public/blob/master/lurk/tests/direct-implementation/svm.lurk)                        |          9 |          1.832 |          0.820 |           0.538 |           0.598 |          2.370 |          1.418 |
 
-*Last Update: Dec 19th, 2023*
 
 <sup>*</sup> The batch-transfer example utilizes `lurk --rc 400 batch_transfer.lurk`, while other tests do not use the `--rc` flag
 </details>
@@ -117,7 +100,6 @@ The programs were compiled using LambdaClass Cairo-VM (v1.0.0-rc0), and were pro
 | [perceptron](https://github.com/Pi-Squared-Network/proof-checker-public/blob/master/risc0/tests/direct-implementation/guest/src/perceptron.rs)       |  21156  |     0.017     |     0.028     |      2.355     |      0.595     |      0.001      |      0.002      |      2.373     |      0.625     |
 | [svm](https://github.com/Pi-Squared-Network/proof-checker-public/blob/master/risc0/tests/direct-implementation/guest/src/svm5.rs)                    |  21156  |     0.028     |     0.028     |      2.351     |      0.602     |      0.002      |      0.002      |      2.381     |      0.632     |
 
-*Last Update: Dec 22th, 2023*
 </details>
 
 <details open>
@@ -130,7 +112,6 @@ The programs were compiled using LambdaClass Cairo-VM (v1.0.0-rc0), and were pro
 | [perceptron](https://github.com/Pi-Squared-Network/proof-checker-public/blob/master/zkllvm/tests/direct-implementation/perceptron)         |                0.750 |                 0.130 |
 | [svm](https://github.com/Pi-Squared-Network/proof-checker-public/blob/master/zkllvm/tests/direct-implementation/svm)                       |                0.730 |                 0.132 |
 
-*Last Update: Jan 8th, 2024*
 </details>
 
 
@@ -147,8 +128,6 @@ The programs were compiled using LambdaClass Cairo-VM (v1.0.0-rc0), and were pro
 | [perceptron-goal](https://github.com/Pi-Squared-Network/proof-checker-public/blob/master/lurk/tests/proofs-of-proofs/test_perceptron_goal.lurk)         | 6404208|             ∞  |             ∞  |              ∞  |               ∞ |              ∞ |              ∞ |
 | [svm-goal](https://github.com/Pi-Squared-Network/proof-checker-public/blob/master/lurk/tests/proofs-of-proofs/test_svm_goal.lurk)                       | 6404208|             ∞  |             ∞  |              ∞  |               ∞ |              ∞ |              ∞ |
 
-*Last Update: Dec 19th, 2023*
-
 <sup>*</sup> The impreflex example utilizes `lurk --rc 400 batch_transfer.lurk`, while other tests do not use the `--rc` flag
 </details>
 
@@ -162,8 +141,6 @@ The programs were compiled using LambdaClass Cairo-VM (v1.0.0-rc0), and were pro
 | batch-transfer-goal | 6724805 |     0.114     |     0.114     |     274.237    |     59.819     |      0.011      |      0.011      |     274.362    |     59.944     |
 | perceptron-goal     | 3212346 |     0.049     |     0.050     |     127.911    |     28.433     |      0.006      |      0.006      |     127.966    |     28.489     |
 | svm-goal            | 3212346 |     0.069     |     0.050     |     128.289    |     28.695     |      0.006      |      0.006      |     128.364    |     28.751     |
-
-*Last Update: Dec 22th, 2023*
 
 <sup>*</sup> The main implementation for RISC Zero $PI^2$ implementation is defined [here](https://github.com/Pi-Squared-Network/proof-checker-public/tree/master/risc0/pi2), and the inputs are defined [here](https://github.com/Pi-Squared-Network/proof-checker-public/tree/master/proofs/translated). The inputs are divided into three files: `*-gamma`, `*-claim`, and `*-proof`.
 Ultimately, we anticipate that all $PI^2$ implementations will support a unique binary input format. As a result, all implementations will utilize the same inputs and have a single main implementation.
@@ -180,7 +157,6 @@ Ultimately, we anticipate that all $PI^2$ implementations will support a unique 
 | perceptron-goal     |              94.530 |                     ∞ |
 | svm-goal            |              93.431 |                     ∞ |
 
-*Last Update: Jan 22nd, 2024*
 
 The main implementation for the zkLLVM $PI^2$ implementation can be found [here](https://github.com/Pi-Squared-Network/proof-checker-public/tree/master/zkllvm/src). We translate the inputs, which are defined [here](https://github.com/Pi-Squared-Network/proof-checker-public/tree/master/proofs/translated). Binary inputs are divided and encoded into three arrays. Each file corresponds to the input requirements of the zkLLVM implementation.
 </details>

--- a/Performance.md
+++ b/Performance.md
@@ -104,7 +104,7 @@ The programs were compiled using LambdaClass Cairo-VM (v1.0.0-rc0), and were pro
 
 *Last Update: Dec 19th, 2023*
 
-<sup>*</sup> The batch-transfer example utilizes `lurk --rc 400 batch_transfer.lurk`, while other tests do not use the `--rc` tag
+<sup>*</sup> The batch-transfer example utilizes `lurk --rc 400 batch_transfer.lurk`, while other tests do not use the `--rc` flag
 </details>
 
 <details open>
@@ -149,7 +149,7 @@ The programs were compiled using LambdaClass Cairo-VM (v1.0.0-rc0), and were pro
 
 *Last Update: Dec 19th, 2023*
 
-<sup>*</sup> The impreflex example utilizes `lurk --rc 400 batch_transfer.lurk`, while other tests do not use the `--rc` tag
+<sup>*</sup> The impreflex example utilizes `lurk --rc 400 batch_transfer.lurk`, while other tests do not use the `--rc` flag
 </details>
 
 <details open>
@@ -163,15 +163,10 @@ The programs were compiled using LambdaClass Cairo-VM (v1.0.0-rc0), and were pro
 | perceptron-goal     | 3212346 |     0.049     |     0.050     |     127.911    |     28.433     |      0.006      |      0.006      |     127.966    |     28.489     |
 | svm-goal            | 3212346 |     0.069     |     0.050     |     128.289    |     28.695     |      0.006      |      0.006      |     128.364    |     28.751     |
 
-> <sup>*</sup>For the RISC Zero $PI^2$ implementation, we have the main implementation defined
-[here](https://github.com/Pi-Squared-Network/proof-checker-public/tree/master/risc0/pi2)
-and the inputs defined [here](https://github.com/Pi-Squared-Network/proof-checker-public/tree/master/proofs/translated).
-The inputs are split into three files: `*-gamma`, `*-claim`, and `*-proof`.
-Ultimately, we expect that all $PI^2$ implementations will support an unique
-binary input format, and therefore, all implementations will share these same
-inputs and have only one main implementation.
+*Last Update: Dec 22th, 2023*
 
-  > Last Update: Dec 22th, 2023
+<sup>*</sup> The main implementation for RISC Zero $PI^2$ implementation is defined [here](https://github.com/Pi-Squared-Network/proof-checker-public/tree/master/risc0/pi2), and the inputs are defined [here](https://github.com/Pi-Squared-Network/proof-checker-public/tree/master/proofs/translated). The inputs are divided into three files: `*-gamma`, `*-claim`, and `*-proof`.
+Ultimately, we anticipate that all $PI^2$ implementations will support a unique binary input format. As a result, all implementations will utilize the same inputs and have a single main implementation.
 </details>
 
 <details open> 
@@ -185,52 +180,33 @@ inputs and have only one main implementation.
 | perceptron-goal     |              94.530 |                     ∞ |
 | svm-goal            |              93.431 |                     ∞ |
 
-> For the zkLLVM $PI^2$ implementation, we have the main implementation defined
-[here](https://github.com/Pi-Squared-Network/proof-checker-public/tree/master/zkllvm/src).
-We translate the inputs defined [here](https://github.com/Pi-Squared-Network/proof-checker-public/tree/master/proofs/translated).
-The binary inputs are split and encoded into three arrays on a file for each file to
-match the input requirements of the zkLLVM implementation.
+*Last Update: Jan 22nd, 2024*
 
-  > Last Update: Jan 22nd, 2024
+The main implementation for the zkLLVM $PI^2$ implementation can be found [here](https://github.com/Pi-Squared-Network/proof-checker-public/tree/master/zkllvm/src). We translate the inputs, which are defined [here](https://github.com/Pi-Squared-Network/proof-checker-public/tree/master/proofs/translated). Binary inputs are divided and encoded into three arrays. Each file corresponds to the input requirements of the zkLLVM implementation.
 </details>
 
 
 ## Implementation Details
 
 ### Lurk Implementation Details
-Lurk is a interpreted programming language, that said, when we execute an
-example in Lurk, we are actually executing the interpreter that will execute the
-program. This means that the execution time required for the interpreter to load
-(interpret) every function and definition is also counted in the execution time
-of the program, and therefore, we can't measure the compilation time of the
-program itself.
 
-To execute large Lurk examples requires an increased swap memory, resulting in
-slower execution times compared to other implementations. Due to this limitation,
-it is difficult to accurately measure and compare execution times between Lurk
-and other implementations. Even though we have 128GB of RAM + 108Gb of swap
-memory, we still couldn't execute most of $PI^2$ examples in Lurk, that what
-the `∞` means on the performance tables.
+Lurk is an interpreted programming language. When we run a Lurk examplee, we are actually executing the interpreter, which in turn executes the program. The execution time includes the time needed for the interpreter to load every function and definition. Consequently, we cannot measure the compilation time of the program itself.
 
-The `--rc n` flag is used to improve the performance execution of larger
-programs in Lurk. The `rc` value is the number of iterations that Lurk packs
-together in a single [Nova](https://github.com/microsoft/Nova) folding step.
-Iterations in Lurk represents reduction steps in the [Lurk Universal Circuit](https://blog.lurk-lang.org/posts/circuit-spec/).
-In terms of parallelism, Lurk is capable of generating more partial witnesses in
-parallel with higher rc values. However, the higher the rc value, the more
-memory is required to execute the program. The default value of `rc` is 10, and
-we used `rc=400` for the `batch-transfer` example. In small cases, a higher `rc`
-value can decrease the execution time, that is why we use it for programs with
-more than 100K iterations.
+Executing large Lurk examples requires an increase in swap memory, which results in slower execution times compared to other implementations. This limitation makes it challenging to measure and compare execution times between Lurk and other implementations accurately. Despite having 128GB of RAM plus 108GB of swap memory, we were still unable to execute most of the $PI^2$ examples in Lurk. The symbol `∞` in the performance tables indicates this inability.
 
-The Lurk's examples were executed within the following version:
+The `--rc n` flag in Lurk is used to enhance execution performance of larger programs. The `rc` value indicates the number of iterations that Lurk bundles together in a single [Nova](https://github.com/microsoft/Nova) folding step. Here, iterations represent reduction steps in the [Lurk Universal Circuit](https://blog.lurk-lang.org/posts/circuit-spec/).
+
+In terms of parallelism, higher `rc` values allow Lurk to generate more partial witnesses simultaneously. However, a larger `rc` value also requires more memory to execute the program. The default `rc` value is 10. For the `batch-transfer` example, we used `rc=400`. In smaller cases, increasing the `rc` value can reduce execution time, which is why it's used for programs with
+over than 100K iterations.
+
+The Lurk examples were run on the following version:
 
 ```bash
 commit: 2023-12-21 510d7042990844760d97d65c7e6c7ab75f934630
 lurk 0.3.1
 ```
 
-To execute the examples using GPU this setup was used to compile the Lurk binary:
+The following setup was used to compile the Lurk binary and run the example using GPU: 
 
 ```bash
 export EC_GPU_CUDA_NVCC_ARGS='--fatbin --gpu-architecture=sm_89 --generate-code=arch=compute_89,code=sm_89'
@@ -241,8 +217,7 @@ export EC_GPU_FRAMEWORK=cuda
 cargo install --path . --features=cuda --force
 ```
 
-To execute the examples using only CPU this setup was used to compile the Lurk
-binary:
+The following setup was used to compile the Lurk binary and run the example using CPU:
 
 ```bash
 export CUDA_PATH=
@@ -253,24 +228,18 @@ cargo install --path . --force
 
 ### RISC Zero Implementation Details
 
-From [RiscZero Terminogy](https://dev.risczero.com/terminology#clock-cycles) the `Cycles` we use in the performance tables are the
-smallest unit of compute in the zkVM circuit, analogous to a clock cycle on a
-physical CPU. The complexity of a guest program's execution is measured in clock
-cycles as they directly affect the memory, proof size, and time performance of
+From the [RiscZero Terminogy](https://dev.risczero.com/terminology#clock-cycles), the `Cycles` we refer to in the performance tables are the smallest unit of computation in the zkVM circuit, similar to a clock cycle on a physical CPU. The execution complexity of a guest program is measured in these clock cycles as they directly impact the memory, proof size, and time performance of
 the zkVM.
 
-Generally, a single cycle corresponds to a single RISC-V operation. However,
-some operations require two cycles.
+Generally, a single cycle corresponds to one RISC-V operation. However, some operations may require two cycles.
 
 ### zkLLVM Implementation Details
 
-zkLLVM doesn't support GPU acceleration in any phase, therefore, we don't have
-GPU results for these experiments.
+zkLLVM does not support GPU acceleration in any stage, so there are no GPU results for these experiments. 
 
-The proof and verification on zkLLVM were genereted using
-`transpiler -m gen-test-proof`.
+The proof and verification for zkLLVM were genereted using the command `transpiler -m gen-test-proof`.
 
-The version of the individual tools used to execute the examples were:
+The versions of the individual tools used for the examples are as follows:
 
 ```bash
 $ clang-17 --version
@@ -283,5 +252,4 @@ $ transpiler --version
 0.1.11-48
 ```
 
-The `∞` on the performance tables means that the example didn't finish executing
-after 6 hours or was killed by the OS due to lack of memory.
+The `∞` symbol in the performance tables indicate that the example either did not finish executing after 6 hours or was terminated by the OS due to lack of memory.

--- a/Performance.md
+++ b/Performance.md
@@ -1,49 +1,40 @@
 # Experiments and Evaluation of ZK Backends
 
-We present our experiments and evaluation of several ZK backends.
+This document outlines our experiments and evaluation of various ZK backends.
 
 ## Benchmark Set Description
 
-We use two benchmark sets for our evaluation:
-Direct Implementation and Proofs of Proofs.
+Our evaluation uses two benchmark sets: Direct Implementation and Proofs of Proofs.
 
 ### Direct Implementation
 
-In this category, we consider four simple programs in the areas of blockchain and AI
-and use several ZK backends to directly generate their ZK proofs.
-These programs are:
+In this category, we consider four simple programs relevant to blockchain and AI. We use various ZK backends to directly generate their ZK proofs.
+The programs include:
 - `transfer`: a simplified version of the ERC20 transfer function;
 - `batch-transfer`: a while loop that executes `transfer` for 5000 times;
 - `perceptron`: a single-layer [perceptron](https://en.wikipedia.org/wiki/Perceptron).
 - `svm`: a [support vector machine (SVM)](https://en.wikipedia.org/wiki/Support_vector_machine)
   model.
 
-The reference pseudocode of these examples are available at the end
-of this document.
+The pseudocode for these examples is provided at the end of this document.
 
-Given a ZK backend, we directly implement these programs in the
-programming language to the backend and generate ZK proof
-of their execution traces.
+For each ZK backend, we directly implement these programs in the respective programming language and generate ZK proofs of their execution traces.
 
 ### Proofs of Proofs
 
-In this category, we combine ZK proofs and logical/mathematical proofs.
-For a program `Pgm` in a programming language `PL`, we use the
-[K framework](https://kframework.org) to generate
-a logical proof `PI(Pgm, PL)` that shows the correctness of an execution
-trace of `Pgm` using directly a formal semantics of `PL`.
-Such a logical proof can be automatically checked by a logical proof checker
-`proof_check(PI(Pgm, PL))`.
-Then, we generate a ZK proof that shows the correctness of
-an execution trace of `proof_check`.
-In other words, we generate a ZK proof that shows the correctness
-of a logical proof that shows the correctness of `Pgm` written in language `PL`.
-Thus, we call this benchmark set Proofs of Proofs, as we generate
-(ZK) proofs of (logical) proofs.
+This category combines ZK proofs and logical/mathematical proofs.
+For a program `Pgm` in a programming language `PL`, we use the [K framework](https://kframework.org) to generate a logical proof `PI(Pgm, PL)`. This proof demonstrates the correctness of an execution trace of `Pgm` using a formal semantics of `PL`.
+
+A logical proof checker can automatically verify `proof_check(PI(Pgm, PL))`. We then generate a ZK proof demonstrating the correctness of an execution trace of `proof_check`.
+
+In essence, we generate a ZK proof that validates the correctness of a logical proof, which in turn verifires the correctness of `Pgm` written in language `PL`. This is why we refer to this benchmark set as Proofs of Proofs--it generates (ZK) proofs of (logical) proofs.
+
+## ZK Backend Evaluation
+This describes the ZK backends we evaluated, including details on their performance.
 
 ### ZK Backends
 
-We consider the following ZK backends:
+The ZK backends under consideration are:
 - [Cairo](https://www.cairo-lang.org/)
 - [Lurk](https://lurk-lang.org/)
 - [RISC Zero](https://www.risczero.com/)
@@ -51,56 +42,74 @@ We consider the following ZK backends:
 
 ## Performance Tables
 
-- machine spec: AMD Ryzen 9 7950X(16 cores/32 threads/128GB), 4090RTX
-- memory swap: 108GB
-- performance time measured in seconds
-- besides RISC Zero, all other implementations were executed using the diff between
-  the timestamps of the start and end of each possible execution phase.
-- RISC Zero has its own performance counter, so we use it to measure the execution time and cycles.
-- "CPU" prefix = without GPU acceleration
-- "GPU" prefix = with GPU acceleration
-- last update date: Dec 19th, 2023.
+- Machine Spec: AMD Ryzen 9 7950X(16 cores/32 threads/128GB), 4090RTX
+- Memory Swap: 108GB
+- Performance Time Measured in Seconds
+- The execution time for all implementations, except RISC Zero, was measured by taking the difference between the start and end timestamps for each execution phace.
+- RISC Zero has its own performance counter, which was used to measure the execution time and cycles.
+- The "CPU" prefix denotes implementation **without** GPU acceleration
+- The "GPU" prefix denotes implementation **with** GPU acceleration
+- Last Update: Dec 19th, 2023
+
+**Other option for this section**
+Some key details about the performance data for the ZK backends. The evaluations were carried out on an AMD Ryzen 9 7950X machine, with 16 cores, 32 threads, and 128GB of memory, paired with a 4090RTX GPU and 108GB of memory swap.
+
+The performance time is measured in seconds, and it's important to note how these times were calculated. For all implementations, except RISC Zero, the execution time was determined by measuring the time differnce between the start and end timestamps of each execution phase. RISC Zero, has its own performance counter that was utilized to measure both the execution time and cycles.
+
+We've also noted where the implementation is using CPU or GPU acceleration. If you see the prefix "CPU", this refers to an implementation without GPU acceleration, whereas "GPU" denotes an implementation that utilized GPU acceleration.
+
+This section was last updated Dec 19th, 2023.
 
 ### Direct Implementation
 
-#### Cairo Zero (v0.13.0)*
-Last Update: Dec 22th, 2023
+<details open>
+<summary>Cairo Zero (v0.13.0)</summary>
+
 |                                                             Examples                                                                            | CPU Exec Time | CPU Prove Time | CPU Verify Time | CPU Total Time |
 |:------------------------------------------------------------------------------------------------------------------------------------------------|:-------------:|:--------------:|:---------------:|:--------------:|
 | [transfer](https://github.com/Pi-Squared-Network/proof-checker-public/blob/master/cairo/tests/direct-implementation/cairo0/transfer.cairo)              |         0.440 |          0.195 |           0.008 |          0.643 |
 | [batch-transfer](https://github.com/Pi-Squared-Network/proof-checker-public/blob/master/cairo/tests/direct-implementation/cairo0/batch_transfer.cairo)  |         6.825 |         30.196 |           0.869 |         37.890 |
 | [perceptron](https://github.com/Pi-Squared-Network/proof-checker-public/blob/master/cairo/tests/direct-implementation/cairo0/perceptron.cairo)          |         0.448 |          0.166 |           0.008 |          0.662 |
 | [svm](https://github.com/Pi-Squared-Network/proof-checker-public/blob/master/cairo/tests/direct-implementation/cairo0/svm.cairo)                        |         0.443 |          0.176 |           0.008 |          0.627 |
+> The programs were compiled using Cairo Zero's default compiler and were proved and verified using Lambdaworks Cairo Platinum Prover (v0.3.0)
 
-\* The programs were compiled with Cairo Zero's default compiler and proved and verified using  Lambdaworks Cairo Platinum Prover (v0.3.0)
+> Last Update: Dec 22th, 2023
 
+</details>
 
-#### Cairo One (v2.3.1)*
-Last Update: Jan 10th, 2024
-|                                                             Examples                                                                            | CPU Exec Time | CPU Prove Time | CPU Verify Time | CPU Total Time |
+<details open>
+  <summary>Cairo One (v2.3.1)</summary>
+
+  |                                                             Examples                                                                            | CPU Exec Time | CPU Prove Time | CPU Verify Time | CPU Total Time |
 |:------------------------------------------------------------------------------------------------------------------------------------------------|:-------------:|:--------------:|:---------------:|:--------------:|
 | [transfer](https://github.com/Pi-Squared-Network/proof-checker-public/blob/master/cairo/tests/direct-implementation/cairo1/transfer.cairo)              |         0.583 |          0.009 |           0.002 |          0.594 |
 | [batch-transfer](https://github.com/Pi-Squared-Network/proof-checker-public/blob/master/cairo/tests/direct-implementation/cairo1/batch_transfer.cairo)  |         0.691 |         65.693 |           1.787 |         68.171 |
 | [perceptron](https://github.com/Pi-Squared-Network/proof-checker-public/blob/master/cairo/tests/direct-implementation/cairo1/perceptron.cairo)          |         0.592 |          0.029 |           0.003 |          0.624 |
 | [svm](https://github.com/Pi-Squared-Network/proof-checker-public/blob/master/cairo/tests/direct-implementation/cairo1/svm.cairo)                        |         0.593 |          0.032 |           0.003 |          0.628 |
 
-\* The programs were compiled with LambdaClass Cairo-VM (v1.0.0-rc0) and proved and verified using Lambdaworks Cairo Platinum Prover (v0.3.0)
+> The programs were compiled using LambdaClass Cairo-VM (v1.0.0-rc0) and were proved and verified using Lambdaworks Cairo Platinum Prover (v0.3.0)
 
+>Last Update: Jan 10th, 2024
+</details>
 
-#### Lurk (v0.3.1)
-Last Update: Dec 19th, 2023
+<details open>
+  <summary>Lurk (v0.3.1)</summary>
+
 |                                                       Examples                                                                         | Iterations | CPU Prove Time | GPU Prove Time | CPU Verify Time | GPU Verify Time | CPU Total Time | GPU Total Time |
 |:--------------------------------------------------------------------------------------------------------------------------------------:|:----------:|:--------------:|:--------------:|:---------------:|:---------------:|:--------------:|:--------------:|
 | [transfer](https://github.com/Pi-Squared-Network/proof-checker-public/blob/master/lurk/tests/direct-implementation/transfer.lurk)              |         34 |          2.393 |          2.313 |           0.554 |           0.618 |          2.947 |          2.931 |
-| [batch-transfer](https://github.com/Pi-Squared-Network/proof-checker-public/blob/master/lurk/tests/direct-implementation/batch_transfer.lurk)* |     505037 |       3681.819 |       1193.355 |           9.845 |           6.571 |       3691.664 |       1199.926 |
+| [batch-transfer](https://github.com/Pi-Squared-Network/proof-checker-public/blob/master/lurk/tests/direct-implementation/batch_transfer.lurk)<sup>*</sup> |     505037 |       3681.819 |       1193.355 |           9.845 |           6.571 |       3691.664 |       1199.926 |
 | [perceptron](https://github.com/Pi-Squared-Network/proof-checker-public/blob/master/lurk/tests/direct-implementation/perceptron.lurk)          |         11 |          3.501 |          0.830 |           0.541 |           0.579 |          4.042 |          1.409 |
 | [svm](https://github.com/Pi-Squared-Network/proof-checker-public/blob/master/lurk/tests/direct-implementation/svm.lurk)                        |          9 |          1.832 |          0.820 |           0.538 |           0.598 |          2.370 |          1.418 |
 
-\* Using `lurk --rc 400 batch_transfer.lurk`, other tests doesn't use `--rc`
+  > <sup>*</sup>Using `lurk --rc 400 batch_transfer.lurk`, other tests doesn't use `--rc`
+  
+  > Last Update: Dec 19th, 2023
+</details>
 
-
-#### RISC Zero (v0.16.1)
-Last Update: Dec 22th, 2023
+<details open>
+  <summary>RISC Zero (v0.16.1)</summary>
+  
 |                                                         Examples                                                                             |  Cycles | CPU Exec Time | GPU Exec Time | CPU Prove Time | GPU Prove Time | CPU Verify Time | GPU Verify Time | CPU Total Time | GPU Total Time |
 |:--------------------------------------------------------------------------------------------------------------------------------------------:|:-------:|:-------------:|:-------------:|:--------------:|:--------------:|:---------------:|:---------------:|:--------------:|:--------------:|
 | [transfer](https://github.com/Pi-Squared-Network/proof-checker-public/blob/master/risc0/tests/direct-implementation/guest/src/transfer.rs)           |  21156  |     0.017     |     0.030     |      2.353     |      0.613     |      0.001      |      0.002      |      2.371     |      0.645     |
@@ -109,8 +118,12 @@ Last Update: Dec 22th, 2023
 | [svm](https://github.com/Pi-Squared-Network/proof-checker-public/blob/master/risc0/tests/direct-implementation/guest/src/svm5.rs)                    |  21156  |     0.028     |     0.028     |      2.351     |      0.602     |      0.002      |      0.002      |      2.381     |      0.632     |
 
 
-#### zkLLVM (v0.1.11-48)
-Last Update: Jan 8th, 2024
+  > Last Update: Dec 22th, 2023
+</details>
+
+<details open>
+  <summary>zkLLVM (v0.1.11-48)</summary>
+
 |                                                  Examples                                                                          | CPU Circuit Gen Time | CPU Prove+Verify Time |
 |:----------------------------------------------------------------------------------------------------------------------------------:|:--------------------:|:---------------------:|
 | [transfer](https://github.com/Pi-Squared-Network/proof-checker-public/blob/master/zkllvm/tests/direct-implementation/transfer)             |                0.730 |                 0.131 |
@@ -118,24 +131,32 @@ Last Update: Jan 8th, 2024
 | [perceptron](https://github.com/Pi-Squared-Network/proof-checker-public/blob/master/zkllvm/tests/direct-implementation/perceptron)         |                0.750 |                 0.130 |
 | [svm](https://github.com/Pi-Squared-Network/proof-checker-public/blob/master/zkllvm/tests/direct-implementation/svm)                       |                0.730 |                 0.132 |
 
+  > Last Update: Jan 8th, 2024
+</details>
+
+
 ### Proofs of Proofs
 
-#### Lurk (v0.3.1)
-Last Update: Dec 19th, 2023
-|                                                            Examples                                                                             | Cycles | CPU Prove Time | GPU Prove Time | CPU Verify Time | GPU Verify Time | CPU Total Time | GPU Total Time |
+<details open>
+  <summary>Lurk (v0.3.1)</summary>
+
+  |                                                            Examples                                                                             | Cycles | CPU Prove Time | GPU Prove Time | CPU Verify Time | GPU Verify Time | CPU Total Time | GPU Total Time |
 |:-----------------------------------------------------------------------------------------------------------------------------------------------:|:------:|:--------------:|:--------------:|:---------------:|:---------------:|:--------------:|:--------------:|
-| [impreflex](https://github.com/Pi-Squared-Network/proof-checker-public/blob/master/lurk/tests/proofs-of-proofs/test_impreflex.lurk)*                    |   55651|        217.268 |        107.558 |           5.800 |           3.967 |        223.068 |        111.525 |
+| [impreflex](https://github.com/Pi-Squared-Network/proof-checker-public/blob/master/lurk/tests/proofs-of-proofs/test_impreflex.lurk)<sup>*</sup>                    |   55651|        217.268 |        107.558 |           5.800 |           3.967 |        223.068 |        111.525 |
 | [transfer-goal](https://github.com/Pi-Squared-Network/proof-checker-public/blob/master/lurk/tests/proofs-of-proofs/test_transfer_goal.lurk)             | 3202986|             ∞  |             ∞  |              ∞  |               ∞ |              ∞ |              ∞ |
 | [batch-transfer-goal](https://github.com/Pi-Squared-Network/proof-checker-public/blob/master/lurk/tests/proofs-of-proofs/test_batch_transfer_goal.lurk) |30122047|             ∞  |             ∞  |              ∞  |               ∞ |              ∞ |              ∞ |
 | [perceptron-goal](https://github.com/Pi-Squared-Network/proof-checker-public/blob/master/lurk/tests/proofs-of-proofs/test_perceptron_goal.lurk)         | 6404208|             ∞  |             ∞  |              ∞  |               ∞ |              ∞ |              ∞ |
 | [svm-goal](https://github.com/Pi-Squared-Network/proof-checker-public/blob/master/lurk/tests/proofs-of-proofs/test_svm_goal.lurk)                       | 6404208|             ∞  |             ∞  |              ∞  |               ∞ |              ∞ |              ∞ |
 
-\* Using `lurk --rc 400 ...`
+> <sup>*</sup> Using `lurk --rc 400 ...`
 
+  > Last Update: Dec 19th, 2023
+</details>
 
-#### RISC Zero (v0.16.1)
-Last Update: Dec 22th, 2023
-|      Examples*      |  Cycles | CPU Exec Time | GPU Exec Time | CPU Prove Time | GPU Prove Time | CPU Verify Time | GPU Verify Time | CPU Total Time | GPU Total Time |
+<details open>
+  <summary>RISC Zero (v0.16.1)</summary>
+
+|      Examples<sup>*</sup>      |  Cycles | CPU Exec Time | GPU Exec Time | CPU Prove Time | GPU Prove Time | CPU Verify Time | GPU Verify Time | CPU Total Time | GPU Total Time |
 |:-------------------:|:-------:|:-------------:|:-------------:|:--------------:|:--------------:|:---------------:|:---------------:|:--------------:|:--------------:|
 | impreflex           |   66366 |     0.031     |     0.030     |       4.754    |      1.256     |      0.001      |      0.001      |       4.786    |      1.287     |
 | transfer-goal       | 1139247 |     0.034     |     0.034     |      48.938    |     10.663     |      0.003      |      0.003      |      48.975    |     10.700     |
@@ -143,7 +164,7 @@ Last Update: Dec 22th, 2023
 | perceptron-goal     | 3212346 |     0.049     |     0.050     |     127.911    |     28.433     |      0.006      |      0.006      |     127.966    |     28.489     |
 | svm-goal            | 3212346 |     0.069     |     0.050     |     128.289    |     28.695     |      0.006      |      0.006      |     128.364    |     28.751     |
 
-\* For the RISC Zero $PI^2$ implementation, we have the main implementation defined
+> <sup>*</sup>For the RISC Zero $PI^2$ implementation, we have the main implementation defined
 [here](https://github.com/Pi-Squared-Network/proof-checker-public/tree/master/risc0/pi2)
 and the inputs defined [here](https://github.com/Pi-Squared-Network/proof-checker-public/tree/master/proofs/translated).
 The inputs are split into three files: `*-gamma`, `*-claim`, and `*-proof`.
@@ -151,9 +172,13 @@ Ultimately, we expect that all $PI^2$ implementations will support an unique
 binary input format, and therefore, all implementations will share these same
 inputs and have only one main implementation.
 
-#### zkLLVM (v0.1.11-48)
-Last Update: Jan 22th, 2024
-|       Examples      |CPU Circuit Gen Time | CPU Prove+Verify Time |
+  > Last Update: Dec 22th, 2023
+</details>
+
+<details open> 
+<summary>zkLLVM (v0.1.11-48)</summary>
+
+  |       Examples      |CPU Circuit Gen Time | CPU Prove+Verify Time |
 |:-------------------:|:-------------------:|:---------------------:|
 | impreflex           |               0.585 |               298.686 |
 | transfer-goal       |              31.585 |             24905.477 |
@@ -161,11 +186,15 @@ Last Update: Jan 22th, 2024
 | perceptron-goal     |              94.530 |                     ∞ |
 | svm-goal            |              93.431 |                     ∞ |
 
-\* For the zkLLVM $PI^2$ implementation, we have the main implementation defined
+> For the zkLLVM $PI^2$ implementation, we have the main implementation defined
 [here](https://github.com/Pi-Squared-Network/proof-checker-public/tree/master/zkllvm/src).
 We translate the inputs defined [here](https://github.com/Pi-Squared-Network/proof-checker-public/tree/master/proofs/translated).
 The binary inputs are split and encoded into three arrays on a file for each file to
 match the input requirements of the zkLLVM implementation.
+
+  > Last Update: Jan 22nd, 2024
+</details>
+
 
 ## Implementation Details
 


### PR DESCRIPTION
I have finished initial edits to `Performance.md`. Please review them when you get a chance. 

What I did: I cleaned up some of the language and then changed some formatting around the tables to make them collapsible. Right now they are all defaulted to `open` but they can be changed to default closed if we ever wanted that.

Immediate feedback needed: The section under **Performance Tables** has two options for how that can look. We can keep the bullet points or I can change them to the paragraphs. I think the paragraphs are better because the bullet points are a little confusing, it's a mixture of information and not one clear idea.

Just a thought: The last comment I have would be that we could group the information better. If we split the sections up into "Lurk", "RISC", and "zkLLVM" that makes more sense to me. It would also mean the tables are spread out through the file more. I didn't make any of these edits. If we decide this will be part of the content for the website then I think we should discuss this more.

